### PR TITLE
use '--enable' switch to generate necessary files only

### DIFF
--- a/template/uRTMv2/K7/sitcp/sources/wishbone/wb_reg/rggen.sh
+++ b/template/uRTMv2/K7/sitcp/sources/wishbone/wb_reg/rggen.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
 file_name="reg_table"
-rggen -c ./config.yml --plugin rggen-verilog ./${file_name}.xlsx -o ./tmp
-mv ./tmp/${file_name}.md ./
-mv ./tmp/${file_name}.v ./
+rggen -c ./config.yml --plugin rggen-verilog --enable verilog_rtl --enable markdown ./${file_name}.xlsx

--- a/template/uRTMv2/K7/sitcp/sources/wishbone/wb_reg/tmp/README.md
+++ b/template/uRTMv2/K7/sitcp/sources/wishbone/wb_reg/tmp/README.md
@@ -1,3 +1,0 @@
-# Temporary folder
-
-


### PR DESCRIPTION
You can generate necessary files only by using the `--enable` switch.
This PR is to apply this switch to the generation script.